### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Various demos are located in the [docs/demos](./docs/demos) directory.
 To install the tech preview, first clone this repository
 
 ```
-$ pip dash-labs
+$ pip install -U dash-labs
 ```
 
 To use the templates based on `dash-bootstrap-components`, a few additional packages are required:
 
 ```
-$ pip dash-bootstrap-components spectra colormath 
+$ pip install -U dash-bootstrap-components spectra colormath 
 ```

--- a/docs/01-Overview.md
+++ b/docs/01-Overview.md
@@ -18,7 +18,7 @@ $ pip install dash-labs
 To use the templates based on `dash-bootstrap-components`, a few additional packages are required:
 
 ```
-$ pip dash-bootstrap-components spectra colormath requests tinycss2
+$ pip install dash-bootstrap-components spectra colormath requests tinycss2
 ```
  
 # Activating Dash Labs Functionality


### PR DESCRIPTION
Minor typo in install instructions

FWIW it's not clear that cloning the repo is required as state just before the `pip` commands?