### PR TITLE
Long callback caching

### DIFF
--- a/dash_labs/plugins/long_callback/__init__.py
+++ b/dash_labs/plugins/long_callback/__init__.py
@@ -46,9 +46,7 @@ def long_callback(
             result_key = user_store_data.get("cache_result_key", None)
             if result_key is None:
                 # Build result cache key from inputs
-                result_key = callback_manager.build_cache_key(
-                    fn, user_callback_args
-                )
+                result_key = callback_manager.build_cache_key(fn, user_callback_args)
                 print(f"create result_key: {result_key}, from {user_callback_args}")
                 user_store_data["cache_result_key"] = result_key
 

--- a/dash_labs/plugins/long_callback/__init__.py
+++ b/dash_labs/plugins/long_callback/__init__.py
@@ -1,7 +1,6 @@
 from functools import partial
 from types import MethodType
 import uuid
-import json
 
 
 class LongCallback:
@@ -23,6 +22,8 @@ def long_callback(
     import dash_core_components as dcc
     from dash_labs.grouping import map_grouping
 
+    callback_manager = self._long_callback_manager
+
     interval_id = dl.build_id("interval")
     interval_component = dcc.Interval(id=interval_id, interval=interval, disabled=True)
 
@@ -34,23 +35,22 @@ def long_callback(
         ".".join([dep.component_id, dep.component_property]) for dep in cancel
     )
 
-    callback_manager = self._long_callback_manager
-
     # Add hidden components to app so we don't need to put them in the layout
     hidden_components = self._extra_hidden_components
     hidden_components.extend([interval_component, store_component])
 
     def wrapper(fn):
-
         background_fn = callback_manager.make_background_fn(fn, progress=bool(progress))
 
         def callback(n_intervals, cancel, user_store_data, user_callback_args):
-            if isinstance(user_callback_args, tuple):
-                key = [list(user_callback_args), user_id]
-            else:
-                key = [user_callback_args, user_id]
-
-            result_key = json.dumps({"args": key})
+            result_key = user_store_data.get("cache_result_key", None)
+            if result_key is None:
+                # Build result cache key from inputs
+                result_key = callback_manager.build_cache_key(
+                    background_fn, user_callback_args
+                )
+                print(f"create result_key: {result_key}")
+                user_store_data["cache_result_key"] = result_key
 
             should_cancel = any(
                 [
@@ -64,52 +64,52 @@ def long_callback(
                 else ()
             )
 
-            if should_cancel:
+            if should_cancel and result_key is not None:
                 if callback_manager.has_future(result_key):
-                    callback_manager.cancel_future(result_key)
+                    callback_manager.delete_future(result_key)
                 return dict(
-                    user_callback_output=map_grouping(
-                        lambda x: dash.no_update, output.dependencies()
-                    ),
+                    user_callback_output=map_grouping(lambda x: dash.no_update, output),
                     in_progress=tuple([val for (_, _, val) in running]),
                     progress=clear_progress,
                     interval_disabled=True,
+                    user_store_data=user_store_data,
                 )
 
             progress_tuple = callback_manager.get_progress(result_key)
 
             if callback_manager.result_ready(result_key):
                 result = callback_manager.get_result(result_key)
-                print(result)
+                # Clear result key
+                user_store_data["cache_result_key"] = None
                 return dict(
                     user_callback_output=result,
                     in_progress=tuple([val for (_, _, val) in running]),
                     progress=clear_progress,
                     interval_disabled=True,
+                    user_store_data=user_store_data,
                 )
             elif progress_tuple:
                 return dict(
-                    user_callback_output=map_grouping(
-                        lambda x: dash.no_update, output.dependencies()
-                    ),
+                    user_callback_output=map_grouping(lambda x: dash.no_update, output),
                     in_progress=tuple([val for (_, val, _) in running]),
                     progress=progress_tuple,
                     interval_disabled=False,
+                    user_store_data=user_store_data,
                 )
             else:
                 callback_manager.terminate_unhealthy_future(result_key)
                 if not callback_manager.has_future(result_key):
+                    print(f"launch for result_key: {result_key}")
                     callback_manager.call_and_register_background_fn(
                         result_key, background_fn, user_callback_args
                     )
 
                 return dict(
-                    user_callback_output=map_grouping(
-                        lambda x: dash.no_update, output.dependencies()
-                    ),
+                    user_callback_output=map_grouping(lambda x: dash.no_update, output),
                     in_progress=tuple([val for (_, val, _) in running]),
                     progress=clear_progress,
                     interval_disabled=False,
+                    user_store_data=user_store_data,
                 )
 
         # Add interval component to inputs
@@ -117,7 +117,7 @@ def long_callback(
             args=dict(
                 n_intervals=dl.Input(interval_id, "n_intervals"),
                 cancel=tuple(dep for dep in cancel),
-                user_store_data=dl.Input(store_id, "data"),
+                user_store_data=dl.State(store_id, "data"),
                 user_callback_args=args,
             ),
             output=dict(
@@ -125,6 +125,7 @@ def long_callback(
                 in_progress=tuple([dep for (dep, _, _) in running]),
                 progress=progress,
                 user_callback_output=output,
+                user_store_data=dl.Output(store_id, "data"),
             ),
             template=template,
         )(callback)

--- a/dash_labs/plugins/long_callback/__init__.py
+++ b/dash_labs/plugins/long_callback/__init__.py
@@ -47,9 +47,9 @@ def long_callback(
             if result_key is None:
                 # Build result cache key from inputs
                 result_key = callback_manager.build_cache_key(
-                    background_fn, user_callback_args
+                    fn, user_callback_args
                 )
-                print(f"create result_key: {result_key}")
+                print(f"create result_key: {result_key}, from {user_callback_args}")
                 user_store_data["cache_result_key"] = result_key
 
             should_cancel = any(

--- a/dash_labs/plugins/long_callback/managers/__init__.py
+++ b/dash_labs/plugins/long_callback/managers/__init__.py
@@ -1,6 +1,6 @@
 from abc import ABC
 import inspect
-
+import hashlib
 
 class BaseLongCallbackManager(ABC):
     def __init__(self, cache_by):
@@ -53,4 +53,4 @@ class BaseLongCallbackManager(ABC):
                 # Call cache function
                 hash_dict[f"cache_key_{i}"] = cache_item()
 
-        return str(hash(str(hash_dict)))
+        return hashlib.sha1(str(hash_dict).encode("utf-8")).hexdigest()

--- a/dash_labs/plugins/long_callback/managers/__init__.py
+++ b/dash_labs/plugins/long_callback/managers/__init__.py
@@ -5,6 +5,9 @@ import hashlib
 class BaseLongCallbackManager(ABC):
     def __init__(self, cache_by):
         # Handle default clear_cache
+        if not isinstance(cache_by, list):
+            cache_by = [cache_by]
+
         self.cache_by = cache_by
 
     def init(self, app):

--- a/dash_labs/plugins/long_callback/managers/__init__.py
+++ b/dash_labs/plugins/long_callback/managers/__init__.py
@@ -2,6 +2,7 @@ from abc import ABC
 import inspect
 import hashlib
 
+
 class BaseLongCallbackManager(ABC):
     def __init__(self, cache_by):
         # Handle default clear_cache

--- a/dash_labs/plugins/long_callback/managers/__init__.py
+++ b/dash_labs/plugins/long_callback/managers/__init__.py
@@ -1,11 +1,16 @@
 from abc import ABC
+import inspect
 
 
 class BaseLongCallbackManager(ABC):
+    def __init__(self, cache_by):
+        # Handle default clear_cache
+        self.cache_by = cache_by
+
     def init(self, app):
         raise NotImplementedError
 
-    def cancel_future(self, key):
+    def delete_future(self, key):
         raise NotImplementedError
 
     def terminate_unhealthy_future(self, key):
@@ -17,7 +22,7 @@ class BaseLongCallbackManager(ABC):
     def get_future(self, key, default=None):
         raise NotImplementedError
 
-    def make_background_fn(self, fn, progress=False):
+    def make_background_fn(self, fn, progress):
         raise NotImplementedError
 
     def call_and_register_background_fn(self, key, background_fn, args):
@@ -31,3 +36,21 @@ class BaseLongCallbackManager(ABC):
 
     def get_result(self, key):
         raise NotImplementedError
+
+    def build_cache_key(self, fn, args):
+        fn_source = inspect.getsource(fn)
+        hash_dict = dict(args=args, fn_source=fn_source)
+
+        if self.cache_by is not None:
+            # Caching enabled
+            for i, cache_item in enumerate(self.cache_by):
+                if isinstance(cache_item, str):
+                    if cache_item == "session":
+                        pass
+                    elif cache_item == "git":
+                        pass
+
+                # Call cache function
+                hash_dict[f"cache_key_{i}"] = cache_item()
+
+        return str(hash(str(hash_dict)))

--- a/dash_labs/plugins/long_callback/managers/flask_caching_manager.py
+++ b/dash_labs/plugins/long_callback/managers/flask_caching_manager.py
@@ -3,23 +3,36 @@ from dash_labs.plugins.long_callback.managers import BaseLongCallbackManager
 
 
 class FlaskCachingCallbackManager(BaseLongCallbackManager):
-    def __init__(self, flask_cache):
+    def __init__(
+        self, flask_cache, clear_cache=None, cache_by=None, cache_timeout=None
+    ):
+        super().__init__(cache_by)
         self.flask_cache = flask_cache
         self.callback_futures = dict()
 
+        # Handle default clear_cache
+        if clear_cache is None:
+            # Clear cache at startup if not caching
+            clear_cache = cache_by is None
+        self.clear_cache = clear_cache
+        self.cache_timeout = cache_timeout
+
     def init(self, app):
         self.flask_cache.init_app(app.server)
-        self.flask_cache.clear()
+        if self.clear_cache:
+            self.flask_cache.clear()
 
-    def cancel_future(self, key):
+    def delete_future(self, key):
         if key in self.callback_futures:
             future = self.callback_futures.pop(key, None)
-            self.flask_cache.set(key, "__undefined__")
             if future:
                 future.kill()
                 future.join()
                 return True
         return False
+
+    def clear_cache_entry(self, key):
+        self.flask_cache.delete(key)
 
     def terminate_unhealthy_future(self, key):
         return False
@@ -31,14 +44,14 @@ class FlaskCachingCallbackManager(BaseLongCallbackManager):
         return self.callback_futures.get(key, default)
 
     def make_background_fn(self, fn, progress=False):
-        return make_update_cache(fn, self.flask_cache, progress)
+        return make_update_cache(fn, self.flask_cache, progress, self.cache_timeout)
 
     @staticmethod
     def _make_progress_key(key):
         return key + "-progress"
 
     def call_and_register_background_fn(self, key, background_fn, args):
-        self.cancel_future(key)
+        self.delete_future(key)
         future = Process(
             target=background_fn, args=(key, self._make_progress_key(key), args)
         )
@@ -56,18 +69,25 @@ class FlaskCachingCallbackManager(BaseLongCallbackManager):
         return self.flask_cache.get(key) not in (None, "__undefined__")
 
     def get_result(self, key):
+        # Get result value
         result = self.flask_cache.get(key)
-        if result not in (None, "__undefined__"):
-            self.cancel_future(key)
-            return result
-        else:
-            return None
+        if result == "__undefined__":
+            result = None
+
+        # Clear result if not caching
+        if self.cache_by is None and result is not None:
+            self.clear_cache_entry(key)
+
+        # Always delete_future (even if we didn't clear cache) so that we can
+        # handle the case where cache entry is cleared externally.
+        self.delete_future(key)
+        return result
 
 
-def make_update_cache(fn, cache, progress):
+def make_update_cache(fn, cache, progress, timeout):
     def _callback(result_key, progress_key, user_callback_args):
         def _set_progress(i, total):
-            cache.set(progress_key, (i, total))
+            cache.set(progress_key, (i, total), timeout=timeout)
 
         maybe_progress = [_set_progress] if progress else []
         if isinstance(user_callback_args, dict):
@@ -76,6 +96,6 @@ def make_update_cache(fn, cache, progress):
             user_callback_output = fn(*maybe_progress, *user_callback_args)
         else:
             user_callback_output = fn(*maybe_progress, user_callback_args)
-        cache.set(result_key, user_callback_output)
+        cache.set(result_key, user_callback_output, timeout=timeout)
 
     return _callback

--- a/dash_labs/templates/base.py
+++ b/dash_labs/templates/base.py
@@ -466,18 +466,18 @@ class BaseTemplate:
 
     @classmethod
     def new_range_slider(
-            cls,
-            min,
-            max,
-            value=Component.UNDEFINED,
-            step=None,
-            tooltip=None,
-            label=Component.UNDEFINED,
-            kind=Input,
-            location=Component.UNDEFINED,
-            component_property="value",
-            id=None,
-            opts=None,
+        cls,
+        min,
+        max,
+        value=Component.UNDEFINED,
+        step=None,
+        tooltip=None,
+        label=Component.UNDEFINED,
+        kind=Input,
+        location=Component.UNDEFINED,
+        component_property="value",
+        id=None,
+        opts=None,
     ):
         if tooltip is None:
             tooltip = (opts or {}).pop(

--- a/docs/07-LongCallback.md
+++ b/docs/07-LongCallback.md
@@ -317,8 +317,11 @@ def callback(n_clicks):
 
 if __name__ == "__main__":
     app.run_server(debug=True)
-
 ```
+
+![](https://i.imgur.com/ficfv7g.gif)
+
+Here you can see that it takes a few seconds to run the callback function, but the cached results are used after `n_clicks` cycles back around to 0.  By interacting with the app in a separate tab, you can see that the cache results are shared across user sessions.
 
 ### cache_by function workflows
 Various `cache_by` functions can be used to accomplish a variety of caching policies. Here are a few examples:

--- a/docs/demos/06-integration-and-migration/adding_controls2.py
+++ b/docs/demos/06-integration-and-migration/adding_controls2.py
@@ -16,7 +16,9 @@ continents = list(df.continent.drop_duplicates())
 
 @app.callback(
     args=dict(
-        year_range=tpl.new_range_slider(min=years[0], max=years[-1], step=5, label="Year"),
+        year_range=tpl.new_range_slider(
+            min=years[0], max=years[-1], step=5, label="Year"
+        ),
         continent=tpl.new_checklist(continents, value=continents, label="Continents"),
         logs=tpl.new_checklist(
             ["log(x)"],
@@ -31,7 +33,7 @@ def callback(year_range, continent, logs):
     # Let parameterize infer output component
     # filter years and calculate mean
     year_df = df[(df.year >= year_range[0]) & (df.year <= year_range[-1])]
-    year_df = year_df.groupby(['country', 'continent']).mean().reset_index()
+    year_df = year_df.groupby(["country", "continent"]).mean().reset_index()
     if continent:
         year_df = year_df[year_df.continent.isin(continent)]
 

--- a/docs/demos/component_plugin_demos/datatable_component_no_template.py
+++ b/docs/demos/component_plugin_demos/datatable_component_no_template.py
@@ -17,8 +17,8 @@ table_plugin = dl.component_plugins.DataTablePlugin(
 
 table_plugin.install_callback(app)
 
-app.layout = html.Div(children=
-    table_plugin.args_components + table_plugin.output_components
+app.layout = html.Div(
+    children=table_plugin.args_components + table_plugin.output_components
 )
 
 if __name__ == "__main__":

--- a/docs/demos/long_callback_examples/long_callback_celery_disable_cancel.py
+++ b/docs/demos/long_callback_examples/long_callback_celery_disable_cancel.py
@@ -21,7 +21,7 @@ from dash_labs.plugins import FlaskCachingCallbackManager, CeleryCallbackManager
 from flask_caching import Cache
 
 flask_cache = Cache(config={"CACHE_TYPE": "filesystem", "CACHE_DIR": "./cache"})
-long_callback_manager = FlaskCachingCallbackManager(flask_cache)
+long_callback_manager = FlaskCachingCallbackManager(flask_cache, clear_cache=True)
 
 app = dash.Dash(
     __name__,

--- a/docs/demos/long_callback_examples/long_callback_celery_loading_state.py
+++ b/docs/demos/long_callback_examples/long_callback_celery_loading_state.py
@@ -21,7 +21,7 @@ from dash_labs.plugins import FlaskCachingCallbackManager, CeleryCallbackManager
 from flask_caching import Cache
 
 flask_cache = Cache(config={"CACHE_TYPE": "filesystem", "CACHE_DIR": "./cache"})
-long_callback_manager = FlaskCachingCallbackManager(flask_cache)
+long_callback_manager = FlaskCachingCallbackManager(flask_cache, clear_cache=True)
 
 app = dash.Dash(
     __name__,

--- a/docs/demos/long_callback_examples/long_callback_celery_progress_bar.py
+++ b/docs/demos/long_callback_examples/long_callback_celery_progress_bar.py
@@ -20,11 +20,7 @@ from dash_labs.plugins import FlaskCachingCallbackManager, CeleryCallbackManager
 from flask_caching import Cache
 
 flask_cache = Cache(config={"CACHE_TYPE": "filesystem", "CACHE_DIR": "./cache"})
-long_callback_manager = FlaskCachingCallbackManager(flask_cache)
-
-# ## FlaskCaching
-flask_cache = Cache(config={"CACHE_TYPE": "filesystem", "CACHE_DIR": "./cache"})
-long_callback_manager = FlaskCachingCallbackManager(flask_cache)
+long_callback_manager = FlaskCachingCallbackManager(flask_cache, clear_cache=True)
 
 app = dash.Dash(
     __name__,

--- a/docs/demos/long_callback_examples/long_callback_celery_simple.py
+++ b/docs/demos/long_callback_examples/long_callback_celery_simple.py
@@ -9,19 +9,21 @@ from dash_labs.plugins import CeleryCallbackManager, FlaskCachingCallbackManager
 # celery_app = Celery(__name__, backend='rpc://', broker='pyamqp://')
 # long_callback_manager = CeleryCallbackManager(celery_app)
 
-# ## Celery on Redis
-# from celery import Celery
-# celery_app = Celery(
-#     __name__, broker='redis://localhost:6379/0', backend='redis://localhost:6379/1'
+## Celery on Redis
+from celery import Celery
+
+celery_app = Celery(
+    __name__, broker="redis://localhost:6379/0", backend="redis://localhost:6379/1"
+)
+long_callback_manager = CeleryCallbackManager(celery_app, cache_by=[lambda: True])
+
+# # ## FlaskCaching
+# from flask_caching import Cache
+#
+# flask_cache = Cache(config={"CACHE_TYPE": "filesystem", "CACHE_DIR": "./cache"})
+# long_callback_manager = FlaskCachingCallbackManager(
+#     flask_cache, clear_cache=True, cache_by=[lambda: True]
 # )
-# long_callback_manager = CeleryCallbackManager(celery_app)
-
-# ## FlaskCaching
-from flask_caching import Cache
-
-flask_cache = Cache(config={"CACHE_TYPE": "filesystem", "CACHE_DIR": "./cache"})
-long_callback_manager = FlaskCachingCallbackManager(flask_cache)
-
 
 app = dash.Dash(
     __name__,

--- a/docs/demos/long_callback_examples/long_callback_disable_cancel_caching.py
+++ b/docs/demos/long_callback_examples/long_callback_disable_cancel_caching.py
@@ -25,9 +25,7 @@ from flask_caching import Cache
 
 flask_cache = Cache(config={"CACHE_TYPE": "filesystem", "CACHE_DIR": "./cache"})
 long_callback_manager = FlaskCachingCallbackManager(
-    flask_cache,
-    clear_cache=True,
-    cache_by=[lambda: launch_uid]
+    flask_cache, clear_cache=True, cache_by=[lambda: launch_uid]
 )
 
 app = dash.Dash(

--- a/docs/demos/long_callback_examples/long_callback_disable_cancel_caching.py
+++ b/docs/demos/long_callback_examples/long_callback_disable_cancel_caching.py
@@ -1,0 +1,66 @@
+import time
+from uuid import uuid4
+import dash
+import dash_html_components as html
+
+import dash_labs as dl
+from dash_labs.plugins import FlaskCachingCallbackManager, CeleryCallbackManager
+
+launch_uid = uuid4()
+
+# ## Celery on RabbitMQ
+# from celery import Celery
+# celery_app = Celery(__name__, backend='rpc://', broker='pyamqp://')
+# long_callback_manager = CeleryCallbackManager(celery_app)
+
+# ## Celery on Redis
+# from celery import Celery
+# celery_app = Celery(
+#     __name__, broker='redis://localhost:6379/0', backend='redis://localhost:6379/1'
+# )
+# long_callback_manager = CeleryCallbackManager(celery_app)
+
+# ## FlaskCaching
+from flask_caching import Cache
+
+flask_cache = Cache(config={"CACHE_TYPE": "filesystem", "CACHE_DIR": "./cache"})
+long_callback_manager = FlaskCachingCallbackManager(
+    flask_cache,
+    clear_cache=True,
+    cache_by=[lambda: launch_uid]
+)
+
+app = dash.Dash(
+    __name__,
+    plugins=[
+        dl.plugins.FlexibleCallbacks(),
+        dl.plugins.HiddenComponents(),
+        dl.plugins.LongCallback(long_callback_manager),
+    ],
+)
+
+app.layout = html.Div(
+    [
+        html.Div([html.P(id="paragraph_id", children=["Button not clicked"])]),
+        html.Button(id="button_id", children="Run Job!"),
+        html.Button(id="cancel_button_id", children="Cancel Running Job!"),
+    ]
+)
+
+
+@app.long_callback(
+    output=(dl.Output("paragraph_id", "children"), dl.Output("button_id", "n_clicks")),
+    args=dl.Input("button_id", "n_clicks"),
+    running=[
+        (dl.Output("button_id", "disabled"), True, False),
+        (dl.Output("cancel_button_id", "disabled"), False, True),
+    ],
+    cancel=[dl.Input("cancel_button_id", "n_clicks")],
+)
+def callback(n_clicks):
+    time.sleep(2.0)
+    return [f"Clicked {n_clicks} times"], (n_clicks or 0) % 4
+
+
+if __name__ == "__main__":
+    app.run_server(debug=True)

--- a/tests/templates/test_component_builders.py
+++ b/tests/templates/test_component_builders.py
@@ -63,6 +63,7 @@ def test_slider_builder(test_template):
 
     assert getattr(component, "tooltip", None) is None
 
+
 def test_range_slider_builder(test_template):
     min, max, step, val, id = 1, 10, 0.5, [2, 5], "test-rangeslider"
     component_dep = test_template.new_range_slider(
@@ -98,6 +99,7 @@ def test_range_slider_builder(test_template):
     component = component_dep.component_id
 
     assert getattr(component, "tooltip", None) is None
+
 
 def test_input_builder(test_template):
     component_dep = test_template.new_textbox(


### PR DESCRIPTION
This PR adds initial support for `long_callback` function memoization.  See the [Caching results with long_callback](https://github.com/plotly/dash-labs/blob/long_callback_caching/docs/07-LongCallback.md#caching-results-with-long_callback) section in chapter 07 of the documentation for more information.