### PR TITLE
allow multiple values in query strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ Unlike other Plotly projects, `dash-labs` does **not** adhere to semantic versio
 ## unreleased
 
 ### Added
- -[#61](https://github.com/plotly/dash-labs/pull/61).  New feature for handling variables in the URL.
-
+ - [#61](https://github.com/plotly/dash-labs/pull/61).  New feature for handling variables in the URL.
+### Fixed
+ - [#73](https://github.com/plotly/dash-labs/pull/73).  Allow for multiple values in query strings.
 ## 1.0.1
 
 ### Fixed

--- a/dash_labs/plugins/pages.py
+++ b/dash_labs/plugins/pages.py
@@ -68,7 +68,7 @@ def register_page(
        e.g. based on path_template: `/asset/<asset_id` to `/asset/none`
        e.g. based on module: `pages.weekly_analytics` to `/weekly-analytics`
 
-    - path_template:
+    - `path_template`:
        Add variables to a URL by marking sections with <variable_name>. The layout function
        then receives the <variable_name> as a keyword argument.
        e.g. path_template= "/asset/<asset_id>"
@@ -471,10 +471,6 @@ def _parse_query_string(search):
     parsed_qs = {}
     for (k, v) in parse_qs(search).items():
         v = v[0] if len(v) == 1 else v
-        try:
-            v = json.loads(v)
-        except:
-            pass
         parsed_qs[k] = v
     return parsed_qs
 

--- a/dash_labs/plugins/pages.py
+++ b/dash_labs/plugins/pages.py
@@ -470,13 +470,12 @@ def _parse_query_string(search):
 
     parsed_qs = {}
     for (k, v) in parse_qs(search).items():
-        first = v[0]  # ignore multiple values
+        v = v[0] if len(v) == 1 else v
         try:
-            first = json.loads(first)
+            v = json.loads(v)
         except:
             pass
-
-        parsed_qs[k] = first
+        parsed_qs[k] = v
     return parsed_qs
 
 


### PR DESCRIPTION
This pull request allows for multiple values in query strings to be passed to the layout function.

For example, this URL has  2 values for `indi`:
```
http://127.0.0.1:8050/chart?com=AAA&indi=sma-50&indi=sma-200
```
The following is now passed to the layout function.  Note that the value for `indi` is a list
```
{'com': 'AAA', 'indi': ['sma-50', 'sma-200']}
```

Previously, only the first value was included:
```
{'com': 'AAA', 'indi': 'sma-50'}
```
