### PR TITLE
Added encoding='utf-8' to open function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Overview
 Unlike other Plotly projects, `dash-labs` does **not** adhere to semantic versioning. This project is intended to make it easier to discuss and iterate on new ideas before they are incorporated into Dash itself. As such, maintaining backward compatibility within the `dash-labs` package is explicitly a non-goal.
 
+## 1.0.4 - May 4, 2022
+### Fixed 
+- added encoding='utf-8' to open function
+
 ## 1.0.3 - March 21, 2022
 
 ### Added

--- a/dash_labs/plugins/pages.py
+++ b/dash_labs/plugins/pages.py
@@ -283,7 +283,7 @@ def _import_layouts_from_pages(pages_folder):
     for (root, dirs, files) in os.walk(pages_folder):
         for file in files:
             if file.endswith(".py") and not file.startswith("_"):
-                with open(os.path.join(root, file)) as f:
+                with open(os.path.join(root, file), encoding='utf-8') as f:
                     content = f.read()
                     if "register_page" not in content:
                         continue


### PR DESCRIPTION
This fixes a bug on Windows machines when opening some .py files in the pages folder