### PR TITLE
Added print_registry()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Overview
 Unlike other Plotly projects, `dash-labs` does **not** adhere to semantic versioning. This project is intended to make it easier to discuss and iterate on new ideas before they are incorporated into Dash itself. As such, maintaining backward compatibility within the `dash-labs` package is explicitly a non-goal.
 
+## Unreleased
+### Added
+- `print_registry()` - Debugging tool and pretty printer for dash.page_registry. 
+
 ## 1.0.4 - May 4, 2022
 ### Fixed 
 - added encoding='utf-8' to open function

--- a/dash_labs/__init__.py
+++ b/dash_labs/__init__.py
@@ -1,2 +1,4 @@
 from . import plugins
 from .version import __version__
+
+from . util import print_registry

--- a/dash_labs/util.py
+++ b/dash_labs/util.py
@@ -1,9 +1,10 @@
 import uuid
 import random
 from collections import OrderedDict
-
-from dash.development.base_component import Component
+import pprint
 import re
+import dash
+from dash.development.base_component import Component
 
 
 # Create dedicated random number generator for build UUIDs
@@ -31,7 +32,7 @@ def build_id(name=None, **kwargs):
     deterministic across multiple executions of an app, and multiple processes running
     the same app.
     """
-    uid = str(uuid.UUID(int=_uid_random.randint(0, 2 ** 128)))
+    uid = str(uuid.UUID(int=_uid_random.randint(0, 2**128)))
     return dict(
         uid=uid,
         **filter_kwargs(name=name, **kwargs),
@@ -114,7 +115,7 @@ def insert_into_ordered_dict(odict, value, key=None, before=None, after=None):
 def add_css_class(component, className):
     """
     Update the className property of a Dash component to include a CSS class name.
-    If one or more classes already exist, the provided className will be be appended
+    If one or more classes already exist, the provided className will  be appended
     to the list. If the provided className is already present, no change will be made
     to the component.
 
@@ -156,3 +157,53 @@ def add_css_class(component, className):
         return
     else:
         component.className = " ".join(all_classes)
+
+
+def print_registry(modules="ALL", exclude=None, include="ALL"):
+    """
+    Debugging tool and pretty printer for dash.page_registry. Prints to the console.
+    Note that if `print_registry()` is called from a file in the `pages` folder, the `dash.page_registry`
+    may not be complete.
+
+    :param modules: (string or list) Default "ALL".  Specifies which modules to print.
+    :param exclude: (string or list) Default None.   Specifies which of the page's  parameter(s) to exclude.
+    :param include: (string or list) Default "ALL".  Prints only the parameters that are specified.
+
+    Examples:
+
+    - `print_registry()`  Will print the entire content of dash.page_registry
+    - `print_registry("pages.home")` will print only one module
+    - `print_registry(__name__)`  will print the current module.  If it's run from app.py it will print all modules
+    - `print_registry(["pages.home", "pages.archive"])` Will print 2 modules
+    - `print_registry(exclude="layout")`  will print info for all the modules, but will exclude the page["layout"]
+    - `print_registry(include=["path", "name"]` will print only the page["path"] and page["name"] for all modules
+    - `print_registry(exclude="ALL") prints the keys (module names) only
+    - `print_registry(include=None) prints the keys (module names) only
+
+    """
+    print(
+        '**Note** When printing from a file in the pages folder, `dash_page_registry` may not be complete.  See the "Print page_registry" docs for more info.'
+    )
+
+    modules = "ALL" if modules == "__main__" else modules
+    if include is None or exclude == "ALL":
+        pprint.pprint(dash.page_registry.keys())
+        return
+
+    if isinstance(modules, str):
+        modules = [modules]
+    if isinstance(exclude, str):
+        exclude = [exclude]
+    if isinstance(include, str):
+        include = [include]
+
+    registry = {}
+    for page in dash.page_registry.values():
+        if modules == ["ALL"] or page["module"] in modules:
+            page_items = {}
+            for k, v in page.items():
+                if include == ["ALL"] or k in include:
+                    if exclude is None or k not in exclude:
+                        page_items[k] = v
+            registry[page["module"]] = page_items
+    pprint.pprint(registry, sort_dicts=False)


### PR DESCRIPTION
Handy debugging tool and pretty printer for `dash.page_registry`.

Note that if `print_registry()` is called from a file in the `pages` folder, the `dash.page_registry`
may not be complete.

:param modules: (string or list) Default "ALL".  Specifies which modules to print.
:param exclude: (string or list) Default None.   Specifies which of the page's  parameter(s) to exclude.
:param include: (string or list) Default "ALL".  Prints only the parameters that are specified.

Examples:
    - `print_registry()`  Will print the entire content of dash.page_registry
    - `print_registry("pages.home")` will print only one module
    - `print_registry(__name__)`  will print the current module.  If it's run from app.py it will print all modules
    - `print_registry(["pages.home", "pages.archive"])` Will print 2 modules
    - `print_registry(exclude="layout")`  will print info for all the modules, but will exclude the page["layout"]
    - `print_registry(include=["path", "name"]` will print only the page["path"] and page["name"] for all modules
    - `print_registry(exclude="ALL")` prints the keys (module names) only  
    - `print_registry(include=None)` prints the keys (module names) only


-------------------


Here's an example of `print_registry()`

```
from dash import Dash, html, dcc
import dash
import dash_labs as dl

app = Dash(__name__, plugins=[dl.plugins.pages])

dash.register_page("another_home", layout=html.Div("We're home!"), path="/")
dash.register_page(
    "very_important", layout=html.Div("Don't miss it!"), path="/important", order=0
)

dl.print_registry()

...
```

Here is a partial output:

```
Dash is running on http://127.0.0.1:8050/

 * Serving Flask app "app" (lazy loading)
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: on
**Note** When printing from a file in the pages folder, `dash_page_registry` may not be complete.  See the "Print page_registry" docs for more info.
{'very_important': {'module': 'very_important',
                    'supplied_path': '/important',
                    'path_template': None,
                    'path': '/important',
                    'supplied_name': None,
                    'name': 'Very important',
                    'supplied_title': None,
                    'title': 'Very important',
                    'description': '',
                    'order': 0,
                    'supplied_order': 0,
                    'supplied_layout': Div("Don't miss it!"),
                    'image': 'app.jpeg',
                    'supplied_image': None,
                    'redirect_from': None,
                    'layout': Div("Don't miss it!")},
 'another_home': {'module': 'another_home',
                  'supplied_path': '/',
                  'path_template': None,
                  'path': '/',
                  'supplied_name': None,
                  'name': 'Another home',
                  'supplied_title': None,
                  'title': 'Another home',
                  'description': '',
                  'order': None,
                  'supplied_order': None,
                  'supplied_layout': Div("We're home!"),
                  'image': 'app.jpeg',
                  'supplied_image': None,
                  'redirect_from': None,
                  'layout': Div("We're home!")},
 'pages.historical_archive': {'module': 'pages.historical_archive',

```

Here is an example with pathnames only:

`print_registry(include="path")'
```

**Note** When printing from a file in the pages folder, `dash_page_registry` may not be complete.  See the "Print page_registry" docs for more info.
{'very_important': {'path': '/important'},
 'another_home': {'path': '/'},
 'pages.historical_archive': {'path': '/historical-archive'},
 'pages.not_found_404': {'path': '/404'},
 'pages.outlook': {'path': '/forward-outlook'},
 'pages.path_variables': {'path': '/asset/inventory/department/branch-1001'},
 'pages.query_string': {'path': '/dashboard'},
 'pages.redirect': {'path': '/redirect'}}

```
         