### PR TITLE
Update meta tag information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cache
 .pytest_cache
 __pycache__
 venv
+.venv

--- a/dash_labs/plugins/pages.py
+++ b/dash_labs/plugins/pages.py
@@ -401,9 +401,9 @@ def plug(app):
             start_page, path_variables = _path_to_page(
                 app, flask.request.path.strip("/")
             )
-            image = start_page.get("image", "")
-            if image:
-                image = app.get_asset_url(image)
+
+            image_url = start_page.get("image_url", "")
+            url = start_page.get("url", "")
 
             title = start_page.get("title", app.title)
             if callable(title):
@@ -424,8 +424,8 @@ def plug(app):
                         <title>{title}</title>
                         <meta name="description" content="{description}" />
                         <!-- Twitter Card data -->
-                        <meta property="twitter:card" content="{description}">
-                        <meta property="twitter:url" content="https://metatags.io/">
+                        <meta property="twitter:card" content="summary_large_image">
+                        <meta property="twitter:url" content="{url}">
                         <meta property="twitter:title" content="{title}">
                         <meta property="twitter:description" content="{description}">
                         <meta property="twitter:image" content="{image}">
@@ -451,8 +451,9 @@ def plug(app):
             ).format(
                 metas=kwargs["metas"],
                 description=description,
+                url=url,
                 title=title,
-                image=image,
+                image=image_url,
                 favicon=kwargs["favicon"],
                 css=kwargs["css"],
                 app_entry=kwargs["app_entry"],

--- a/dash_labs/plugins/pages.py
+++ b/dash_labs/plugins/pages.py
@@ -402,8 +402,12 @@ def plug(app):
                 app, flask.request.path.strip("/")
             )
 
-            image_url = start_page.get("image_url", "")
-            url = start_page.get("url", "")
+            image = start_page.get("image", "")
+            if image:
+                image = app.get_asset_url(image)
+
+            # get the specified url or create it based on the passed in image
+            image_url = start_page.get("image_url", "".join([flask.request.url_root, image.lstrip("/")]))
 
             title = start_page.get("title", app.title)
             if callable(title):
@@ -428,7 +432,7 @@ def plug(app):
                         <meta property="twitter:url" content="{url}">
                         <meta property="twitter:title" content="{title}">
                         <meta property="twitter:description" content="{description}">
-                        <meta property="twitter:image" content="{image}">
+                        <meta property="twitter:image" content="{image_full}">
                         <!-- Open Graph data -->
                         <meta property="og:title" content="{title}" />
                         <meta property="og:type" content="website" />
@@ -451,9 +455,10 @@ def plug(app):
             ).format(
                 metas=kwargs["metas"],
                 description=description,
-                url=url,
+                url=flask.request.url,
                 title=title,
-                image=image_url,
+                image=image,
+                image_full=image_url,
                 favicon=kwargs["favicon"],
                 css=kwargs["css"],
                 app_entry=kwargs["app_entry"],

--- a/dash_labs/plugins/pages.py
+++ b/dash_labs/plugins/pages.py
@@ -183,6 +183,7 @@ def register_page(
     page.update(
         image=(image if image is not None else _infer_image(module)),
         supplied_image=image,
+        image_url=image_url
     )
     page.update(redirect_from=redirect_from)
 

--- a/dash_labs/plugins/pages.py
+++ b/dash_labs/plugins/pages.py
@@ -42,6 +42,7 @@ def register_page(
     title=None,
     description=None,
     image=None,
+    image_url=None,
     redirect_from=None,
     layout=None,
     **kwargs,
@@ -99,6 +100,11 @@ def register_page(
         - A generic app image at `assets/app.<extension>`
         - A logo at `assets/logo.<extension>`
         When inferring the image file, it will look for the following extensions: APNG, AVIF, GIF, JPEG, PNG, SVG, WebP.
+
+    - `image_url`:
+       This will use the exact image url provided when sharing on social media. 
+       This is appealing when the image you want to share is hosted on a CDN.
+       Using this attribute overrides the image attribute.
 
     - `redirect_from`:
        A list of paths that should redirect to this page.
@@ -432,7 +438,7 @@ def plug(app):
                         <meta property="twitter:url" content="{url}">
                         <meta property="twitter:title" content="{title}">
                         <meta property="twitter:description" content="{description}">
-                        <meta property="twitter:image" content="{image_full}">
+                        <meta property="twitter:image" content="{image}">
                         <!-- Open Graph data -->
                         <meta property="og:title" content="{title}" />
                         <meta property="og:type" content="website" />
@@ -457,8 +463,7 @@ def plug(app):
                 description=description,
                 url=flask.request.url,
                 title=title,
-                image=image,
-                image_full=image_url,
+                image=image_url,
                 favicon=kwargs["favicon"],
                 css=kwargs["css"],
                 app_entry=kwargs["app_entry"],

--- a/docs/10-MultiPageDashApp-MetaTags.md
+++ b/docs/10-MultiPageDashApp-MetaTags.md
@@ -33,7 +33,7 @@ See the code in `/demos/multi_page_meta_tags`
    These are the [most commonly used image file types](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types) used on the web.
 - `image_url`:
    The image url is used to point to a hosted image online through its full path.
-   The head matter does not handle relative paths (as far as I know), so we need to supply the full path.
+   If the image_url is not provided, we will automatically create the full url based on the `image` attribute.
 
 Example of the difference between `image` and `image_url`:
 `image=birdhouse.jpeg` and `image_url=http://www.yourdomain.com/assets/birdhouse.jpeg`
@@ -95,7 +95,6 @@ dash.register_page(
     path="/",
     image="birdhouse.jpeg",
     image_url="http://yourdomain.com/assets/birdhouse.jpeg",
-    url="http://yourdomain.com/",   # matches the path parameter with the full domain
     title="(home) The title, headline or name of the page",
     description="(home) A short description or summary 2-3 sentences",
 )

--- a/docs/10-MultiPageDashApp-MetaTags.md
+++ b/docs/10-MultiPageDashApp-MetaTags.md
@@ -31,6 +31,12 @@ See the code in `/demos/multi_page_meta_tags`
     - A logo at `assets/logo.<extension>`
    When inferring the image file, it will look for the following extensions: APNG, AVIF, GIF, JPEG, PNG, SVG, WebP.
    These are the [most commonly used image file types](https://developer.mozilla.org/en-US/docs/Web/Media/Formats/Image_types) used on the web.
+- `image_url`:
+   The image url is used to point to a hosted image online through its full path.
+   The head matter does not handle relative paths (as far as I know), so we need to supply the full path.
+
+Example of the difference between `image` and `image_url`:
+`image=birdhouse.jpeg` and `image_url=http://www.yourdomain.com/assets/birdhouse.jpeg`
 
 In the `assets` folder we have 4 jpeg images with the following file names:  
 - app.jpeg
@@ -39,6 +45,8 @@ In the `assets` folder we have 4 jpeg images with the following file names:
 - logo.jpeg
 
 The `title` and `description` will be derrived from the module name if none is supplied.
+
+The `url` will be the full url when deployed. Twitter needs the full url to properly supply a card.
 
 In the `pages` folder we have 3 simple pages to demonstrate this feature. 
 
@@ -86,6 +94,8 @@ dash.register_page(
     __name__,
     path="/",
     image="birdhouse.jpeg",
+    image_url="http://yourdomain.com/assets/birdhouse.jpeg",
+    url="http://yourdomain.com/",   # matches the path parameter with the full domain
     title="(home) The title, headline or name of the page",
     description="(home) A short description or summary 2-3 sentences",
 )

--- a/docs/demos/multi_page_meta_tags/pages/home.py
+++ b/docs/demos/multi_page_meta_tags/pages/home.py
@@ -6,8 +6,6 @@ dash.register_page(
     __name__,
     path="/",
     image="birdhouse.jpeg",
-    image_url="url_to_image_whereever_its_hosted",
-    url="overall_site_url",
     title="(home) The title, headline or name of the page",
     description="(home) A short description or summary 2-3 sentences",
 )

--- a/docs/demos/multi_page_meta_tags/pages/home.py
+++ b/docs/demos/multi_page_meta_tags/pages/home.py
@@ -6,6 +6,8 @@ dash.register_page(
     __name__,
     path="/",
     image="birdhouse.jpeg",
+    image_url="url_to_image_whereever_its_hosted",
+    url="overall_site_url",
     title="(home) The title, headline or name of the page",
     description="(home) A short description or summary 2-3 sentences",
 )


### PR DESCRIPTION
**This is not fully tested,** I do not have access to a domain I can test on to ensure that this works. This will need to be deployed to a domain in order to test properly. We can use [https://metatags.io/](https://metatags.io/) to ensure things are showing up properly after deploying.


I'm am not 100% sure how we should handle the image url and url information.

The changes can be described as the following:
- `twitter:card` will be set to "summary_large_image", this could perhaps be the default and we allow the user to choose the proper card type; however, I think this is the most often used Twitter card for sharing websites.
- `image_url` is a new parameter to pass into each page. I figure that some people might enjoy accessing the image locally (through the assets folder using image), but we need to point to a proper image location for sharing.
- `url` is used to specify the full path of the deployed instance instead of the relative path. 